### PR TITLE
Adds cursor-based chapter pagination

### DIFF
--- a/api/internal/domain/chapter.go
+++ b/api/internal/domain/chapter.go
@@ -1,5 +1,19 @@
 package domain
 
+import "cloud.google.com/go/firestore"
+
+type CursorOptions struct {
+	NovelID string              `json:"novel_id"`
+	Cursor  string              `json:"cursor"`
+	Limit   int                 `json:"limit"`
+	SortBy  firestore.Direction `json:"sort_by"`
+}
+
+type CursorResponse struct {
+	Chapters   []Chapter `json:"chapters"`
+	NextCursor string    `json:"next_cursor"`
+}
+
 type Chapter struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`

--- a/api/internal/infrastructure/collections/chapters.go
+++ b/api/internal/infrastructure/collections/chapters.go
@@ -28,7 +28,7 @@ func (c *Client) BatchUploadChapters(novelId string, chapters []domain.Chapter, 
 			job, err := bw.Set(coll.Doc(chap.ID), chap)
 			if err != nil {
 				return &cmn.Error{
-					Err:    fmt.Errorf("enqueue failed for chapter %s: %w", chap.ID, err),
+					Err:    fmt.Errorf("Firestore Client Error - Batch Upload Chapters - Enqueue failed for chapter %s: %w", chap.ID, err),
 					Status: http.StatusInternalServerError,
 				}
 			}
@@ -43,7 +43,7 @@ func (c *Client) BatchUploadChapters(novelId string, chapters []domain.Chapter, 
 			if _, err := job.Results(); err != nil {
 				chap := subset[j]
 				return &cmn.Error{
-					Err:    fmt.Errorf("write failed for chapter %s: %w", chap.ID, err),
+					Err:    fmt.Errorf("Firestore Client Error - Batch Upload Chapters - Write failed for chapter %s: %w", chap.ID, err),
 					Status: http.StatusInternalServerError,
 				}
 			}

--- a/api/internal/interfaces/rest/routes.go
+++ b/api/internal/interfaces/rest/routes.go
@@ -46,6 +46,7 @@ func RegisteredRoutes(r *gin.Engine) {
 		client.GET("/:novel", firestore_handlers.FindNovel)
 		client.GET("/:novel/all", firestore_handlers.FindAllChapters)
 		client.GET("/:novel/:chapter", firestore_handlers.FindChapter)
+		client.GET("/:novel/chapters", firestore_handlers.GetPaginatedChapters)
 	}
 
 	manage := r.Group("/manage")
@@ -57,7 +58,6 @@ func RegisteredRoutes(r *gin.Engine) {
 		manage.PUT("/:novel/:chapter", firestore_middleware.ValidateToken(), firestore_handlers.UpdateChapter)
 		manage.DELETE("/:novel", firestore_middleware.ValidateToken(), firestore_handlers.DeleteNovel)
 		manage.DELETE("/:novel/:chapter", firestore_middleware.ValidateToken(), firestore_handlers.DeleteChapter)
-
 	}
 
 	user := r.Group("/user")

--- a/api/internal/usecases/collections/chapters.go
+++ b/api/internal/usecases/collections/chapters.go
@@ -11,6 +11,27 @@ import (
 	"time"
 )
 
+func GetCursorPaginatedChapters(options domain.CursorOptions, ctx context.Context) (*domain.CursorResponse, error) {
+	client, err := firestore_client.FirestoreClient()
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	c := firestore_collections.Client{Client: client}
+
+	if options.Limit > 100 || options.Limit <= 0 {
+		options.Limit = 100
+	}
+
+	response, err := c.CursorPagination(options, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func BatchUploadChapters(novelId string, chapters []domain.Chapter, ctx context.Context) error {
 	client, err := firestore_client.FirestoreClient()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/bytedance/sonic/loader v0.2.3 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.0.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
+github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/gin-contrib/cors v1.7.3 h1:hV+a5xp8hwJoTw7OY+a70FsL8JkVVFTXw9EcfrYUdns=


### PR DESCRIPTION
Implements a new API endpoint and underlying logic to retrieve chapters for a novel using cursor-based pagination. This allows for efficient fetching of large chapter lists by providing a `cursor` and `limit` for incremental data retrieval.

*   Introduces `CursorOptions` and `CursorResponse` domain models to standardize pagination requests and responses.
*   Develops a new Firestore collection method to perform efficient `StartAfter` queries for paginated chapter data.
*   Adds a use case to manage the pagination business logic, including client initialization and limit enforcement.
*   Exposes a `GET /client/:novel/chapters` REST endpoint, supporting `cursor` and `limit` query parameters for flexible data fetching.
*   Enhances error messages for clarity in batch chapter operations.