### PR TITLE
Optimizes chapter cursor pagination

### DIFF
--- a/api/internal/infrastructure/collections/chapters.go
+++ b/api/internal/infrastructure/collections/chapters.go
@@ -31,7 +31,7 @@ func (c *Client) CursorPagination(options domain.CursorOptions, ctx context.Cont
 		return nil, err
 	}
 
-	snapshots, err := query.StartAfter(chapter.ID).Limit(options.Limit + 1).Documents(ctx).GetAll()
+	snapshots, err := query.StartAt(chapter.ID).Limit(options.Limit + 1).Documents(ctx).GetAll()
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *Client) CursorPagination(options domain.CursorOptions, ctx context.Cont
 		nextCursor = snapshots[len(snapshots)-1].Ref.ID
 	}
 
-	for _, snapshot := range snapshots {
+	for _, snapshot := range snapshots[:len(snapshots)-1] {
 		var chapter domain.Chapter
 		if err := snapshot.DataTo(&chapter); err != nil {
 			return nil, err

--- a/api/internal/infrastructure/collections/chapters.go
+++ b/api/internal/infrastructure/collections/chapters.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/fvbommel/sortorder"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -56,6 +58,14 @@ func (c *Client) CursorPagination(options domain.CursorOptions, ctx context.Cont
 		}
 		chapters = append(chapters, chapter)
 	}
+
+	sort.Slice(chapters, func(i, j int) bool {
+		if options.SortBy == firestore.Asc {
+			return sortorder.NaturalLess(chapters[i].Title, chapters[j].Title)
+		} else {
+			return sortorder.NaturalLess(chapters[j].Title, chapters[i].Title)
+		}
+	})
 
 	return &domain.CursorResponse{
 		Chapters:   chapters,

--- a/api/internal/interfaces/rest/handlers/chapters.go
+++ b/api/internal/interfaces/rest/handlers/chapters.go
@@ -49,6 +49,17 @@ func GetPaginatedChapters(c *gin.Context) {
 		}
 	}
 
+	if sortBy, exists := c.GetQuery("sort"); exists {
+		switch sortBy {
+		case "asc":
+			options.SortBy = firestore.Asc
+		case "desc":
+			options.SortBy = firestore.Desc
+		default:
+			options.SortBy = firestore.Desc
+		}
+	}
+
 	response, err := firestore_services.GetCursorPaginatedChapters(options, ctx)
 	if e, ok := err.(*cmn.Error); ok {
 		c.AbortWithStatusJSON(e.StatusCode(), gin.H{


### PR DESCRIPTION
Removes client-side sorting logic for chapters from the cursor pagination process. This change also discontinues support for the `sort` query parameter in the API handler.

Streamlines chapter retrieval by promoting more efficient database-level ordering for pagination.