### PR TITLE
Potential fix for code scanning alert no. 1: Slice memory allocation with excessive size value

### DIFF
--- a/api/internal/infrastructure/collections/chapters.go
+++ b/api/internal/infrastructure/collections/chapters.go
@@ -45,7 +45,15 @@ func (c *Client) CursorPagination(options domain.CursorOptions, ctx context.Cont
 		}
 	}
 
-	chapters := make([]domain.Chapter, 0, options.Limit)
+	// Clamp options.Limit to a safe range before allocation
+	limit := options.Limit
+	if limit > 100 {
+		limit = 100
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	chapters := make([]domain.Chapter, 0, limit)
 	nextCursor := ""
 	if len(snapshots) > options.Limit {
 		nextCursor = snapshots[len(snapshots)-1].Ref.ID


### PR DESCRIPTION
Potential fix for [https://github.com/FinnTheHero/Codex-Backend/security/code-scanning/1](https://github.com/FinnTheHero/Codex-Backend/security/code-scanning/1)

To fix the problem, we should ensure that the value used for slice allocation (`options.Limit`) is always within a safe, predefined range at the point of allocation. The best way to do this is to clamp `options.Limit` to a maximum allowed value (e.g., 100) and a minimum (e.g., 1) immediately before using it in the `make` function in `CursorPagination`. This ensures that, regardless of upstream logic or future code changes, the allocation cannot be abused. 

Specifically, in `api/internal/infrastructure/collections/chapters.go`, before the line that allocates the slice, add logic to clamp `options.Limit` to a safe range (e.g., 1 to 100). This can be done with a simple if-statement. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
