### PR TITLE
Renames nextCursor JSON to snake_case

### DIFF
--- a/api/internal/infrastructure/collections/chapters.go
+++ b/api/internal/infrastructure/collections/chapters.go
@@ -55,7 +55,12 @@ func (c *Client) CursorPagination(options domain.CursorOptions, ctx context.Cont
 		nextCursor = snapshots[len(snapshots)-1].Ref.ID
 	}
 
-	for _, snapshot := range snapshots[:len(snapshots)-1] {
+	snapLen := len(snapshots) - 1
+	if snapLen <= 0 {
+		snapLen++
+	}
+
+	for _, snapshot := range snapshots[:snapLen] {
 		var chapter domain.Chapter
 		if err := snapshot.DataTo(&chapter); err != nil {
 			return nil, err

--- a/api/internal/interfaces/rest/handlers/chapters.go
+++ b/api/internal/interfaces/rest/handlers/chapters.go
@@ -74,8 +74,8 @@ func GetPaginatedChapters(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"chapters":   &response.Chapters,
-		"nextCursor": &response.NextCursor,
+		"chapters":    &response.Chapters,
+		"next_cursor": &response.NextCursor,
 	})
 }
 


### PR DESCRIPTION
Standardizes the `nextCursor` JSON field name to `snake_case` in API responses. This improves consistency with common API naming conventions.
Fix handling singular chapter case.