### PR TITLE
Configures Gin mode from environment variable

### DIFF
--- a/api/internal/interfaces/rest/server.go
+++ b/api/internal/interfaces/rest/server.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Server() {
-	gin.SetMode(gin.DebugMode)
+	gin.SetMode(os.Getenv("GIN_MODE"))
 
 	r := gin.Default()
 


### PR DESCRIPTION
Sets the Gin mode (e.g., debug, release) based on the value of the `GIN_MODE` environment variable. This allows for different configurations in development and production environments without requiring code changes.