### PR TITLE
Replaces direct env access with helper function

### DIFF
--- a/api/internal/interfaces/rest/server.go
+++ b/api/internal/interfaces/rest/server.go
@@ -1,11 +1,18 @@
 package firestore_server
 
 import (
+	cmn "Codex-Backend/api/internal/common"
+
 	"github.com/gin-gonic/gin"
 )
 
 func Server() {
-	gin.SetMode(os.Getenv("GIN_MODE"))
+	mode, err := cmn.GetEnvVariable("GIN_MODE")
+	if err != nil {
+		panic(err)
+	}
+
+	gin.SetMode(mode)
 
 	r := gin.Default()
 

--- a/api/internal/interfaces/rest/server.go
+++ b/api/internal/interfaces/rest/server.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Server() {
-	gin.SetMode(gin.DebugMode)
+	gin.SetMode(os.Getenv("GIN_MODE"))
 
 	r := gin.Default()
 


### PR DESCRIPTION
- Uses `GetEnvVariable` function to retrieve environment variables.
- Prevents direct use of `os.Getenv` for better error handling and consistency.