### PR TITLE
Replaces os.Getenv with GetEnvVariable

### DIFF
--- a/api/internal/interfaces/rest/server.go
+++ b/api/internal/interfaces/rest/server.go
@@ -1,11 +1,18 @@
 package firestore_server
 
 import (
+	cmn "Codex-Backend/api/internal/common"
+
 	"github.com/gin-gonic/gin"
 )
 
 func Server() {
-	gin.SetMode(os.Getenv("GIN_MODE"))
+	mode, err := cmn.GetEnvVariable("GIN_MODE")
+	if err != nil {
+		panic(err)
+	}
+
+	gin.SetMode(mode)
 
 	r := gin.Default()
 


### PR DESCRIPTION
Replaces direct use of `os.Getenv` with a custom `GetEnvVariable`
function from the `common` package. This change enhances error
handling and allows for more robust environment variable retrieval.
