### PR TITLE
Skips token validation on auth routes

### DIFF
--- a/api/internal/server/middleware/token/token.go
+++ b/api/internal/server/middleware/token/token.go
@@ -15,6 +15,12 @@ import (
 
 func SetClaimsFromToken() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		if path == "/api/user/refresh" || path == "/api/user/logout" || path == "/api/user/login" {
+			c.Next()
+			return
+		}
+
 		tokenString, err := ExtractToken(c)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{


### PR DESCRIPTION
The token validation middleware now bypasses token extraction and claim setting for critical authentication endpoints. This ensures that routes such as `/api/user/login`, `/api/user/refresh`, and `/api/user/logout` can operate correctly without requiring a valid access token upfront.

This adjustment prevents premature unauthorized errors, allowing the respective handlers to manage initial authentication, token renewal, or token invalidation processes as intended.